### PR TITLE
Update to Rust 1.54

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -9,11 +9,11 @@ inherit cargo_common
 CARGO = "cargo"
 
 # We need cargo to compile for the target
-BASEDEPENDS:append = " cargo-native"
+BASEDEPENDS_append = " cargo-native"
 
 # Ensure we get the right rust variant
-DEPENDS:append:class-target = " virtual/${TARGET_PREFIX}rust ${RUSTLIB_DEP}"
-DEPENDS:append:class-native = " rust-native"
+DEPENDS_append_class-target = " virtual/${TARGET_PREFIX}rust ${RUSTLIB_DEP}"
+DEPENDS_append_class-native = " rust-native"
 
 # Enable build separation
 B = "${WORKDIR}/build"

--- a/classes/rust-bin.bbclass
+++ b/classes/rust-bin.bbclass
@@ -1,6 +1,6 @@
 inherit rust
 
-RDEPENDS:${PN}:append:class-target = " ${RUSTLIB_DEP}"
+RDEPENDS:${PN}_append_class-target = " ${RUSTLIB_DEP}"
 
 RUSTC_ARCHFLAGS += "-C opt-level=3 -g -L ${STAGING_DIR_HOST}/${rustlibdir} -C linker=${RUST_TARGET_CCLD}"
 EXTRA_OEMAKE += 'RUSTC_ARCHFLAGS="${RUSTC_ARCHFLAGS}"'
@@ -146,4 +146,3 @@ do_rust_bin_fixups() {
     done
 }
 PACKAGE_PREPROCESS_FUNCS += "do_rust_bin_fixups"
-

--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -1,8 +1,8 @@
 # Common variables used by all Rust builds
 export rustlibdir = "${libdir}/rust"
-FILES:${PN} += "${rustlibdir}/*.so"
-FILES:${PN}-dev += "${rustlibdir}/*.rlib ${rustlibdir}/*.rmeta"
-FILES:${PN}-dbg += "${rustlibdir}/.debug"
+FILES_${PN} += "${rustlibdir}/*.so"
+FILES_${PN}-dev += "${rustlibdir}/*.rlib ${rustlibdir}/*.rmeta"
+FILES_${PN}-dbg += "${rustlibdir}/.debug"
 
 RUSTLIB = "-L ${STAGING_LIBDIR}/rust"
 RUST_DEBUG_REMAP = "--remap-path-prefix=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}"
@@ -14,7 +14,7 @@ RUST_PANIC_STRATEGY ?= "unwind"
 # Native builds are not effected by TCLIBC. Without this, rust-native
 # thinks it's "target" (i.e. x86_64-linux) is a musl target.
 RUST_LIBC = "${TCLIBC}"
-RUST_LIBC:class-native = "glibc"
+RUST_LIBC_class-native = "glibc"
 
 def determine_libc(d, thing):
     '''Determine which libc something should target'''

--- a/classes/rust.bbclass
+++ b/classes/rust.bbclass
@@ -15,7 +15,7 @@ def rust_base_dep(d):
             deps += " rust-native"
     return deps
 
-DEPENDS:append = " ${@rust_base_dep(d)}"
+DEPENDS_append = " ${@rust_base_dep(d)}"
 
 # BUILD_LDFLAGS
 # 	${STAGING_LIBDIR_NATIVE}
@@ -42,4 +42,4 @@ rustlib_suffix="${TUNE_ARCH}${TARGET_VENDOR}-${TARGET_OS}/rustlib/${HOST_SYS}/li
 rustlib_src="${prefix}/lib/${rustlib_suffix}"
 # Host sysroot standard library path
 rustlib="${libdir}/${rustlib_suffix}"
-rustlib:class-native="${libdir}/rustlib/${BUILD_SYS}/lib"
+rustlib_class-native="${libdir}/rustlib/${BUILD_SYS}/lib"

--- a/conf/distro/include/rust_security_flags.inc
+++ b/conf/distro/include/rust_security_flags.inc
@@ -1,7 +1,7 @@
 # Build errors with PIE options enabled
-SECURITY_CFLAGS:pn-rust-native = "${SECURITY_NO_PIE_CFLAGS}"
-SECURITY_CFLAGS:pn-rust-cross-${TARGET_ARCH} = "${SECURITY_NO_PIE_CFLAGS}"
-SECURITY_CFLAGS:pn-rust = "${SECURITY_NO_PIE_CFLAGS}"
-SECURITY_CFLAGS:pn-rust-llvm = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-rust-native = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-rust-cross-${TARGET_ARCH} = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-rust = "${SECURITY_NO_PIE_CFLAGS}"
+SECURITY_CFLAGS_pn-rust-llvm = "${SECURITY_NO_PIE_CFLAGS}"
 
-SECURITY_LDFLAGS:pn-rust-cross-arm = " -lssp_nonshared -lssp"
+SECURITY_LDFLAGS_pn-rust-cross-arm = " -lssp_nonshared -lssp"

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -25,7 +25,7 @@
 #MACHINE ?= "qemux86"
 #MACHINE ?= "qemux86-64"
 #
-# There are also the following hardware board target machines included for 
+# There are also the following hardware board target machines included for
 # demonstration purposes:
 #
 #MACHINE ?= "beaglebone"
@@ -83,12 +83,12 @@ MACHINE ??= "qemux86-64"
 #
 # The distribution setting controls which policy settings are used as defaults.
 # The default value is fine for general Yocto project use, at least initially.
-# Ultimately when creating custom policy, people will likely end up subclassing 
+# Ultimately when creating custom policy, people will likely end up subclassing
 # these defaults.
 #
 DISTRO ?= "poky"
 # As an example of a subclass there is a "bleeding" edge policy configuration
-# where many versions are set to the absolute latest code from the upstream 
+# where many versions are set to the absolute latest code from the upstream
 # source control systems. This is just mentioned here as an example, its not
 # useful to most new users.
 # DISTRO ?= "poky-bleeding"
@@ -232,8 +232,8 @@ INHERIT += "own-mirrors rm_work"
 # seen. The two lines below enable the SDL backend too. By default libsdl-native will
 # be built, if you want to use your host's libSDL instead of the minimal libsdl built
 # by libsdl-native then uncomment the ASSUME_PROVIDED line below.
-PACKAGECONFIG:append:pn-qemu-native = " sdl"
-PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
+PACKAGECONFIG:append_pn-qemu-native = " sdl"
+PACKAGECONFIG:append_pn-nativesdk-qemu = " sdl"
 #ASSUME_PROVIDED += "libsdl-native"
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to

--- a/recipes-core/packagegroups/packagegroup-rust-cross-canadian.bb
+++ b/recipes-core/packagegroups/packagegroup-rust-cross-canadian.bb
@@ -9,10 +9,9 @@ RUST="rust-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 CARGO="cargo-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 RUST_TOOLS="rust-tools-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 
-RDEPENDS:${PN} = " \
+RDEPENDS_${PN} = " \
     ${@all_multilib_tune_values(d, 'RUST')} \
     ${@all_multilib_tune_values(d, 'CARGO')} \
     rust-cross-canadian-src \
     ${@all_multilib_tune_values(d, 'RUST_TOOLS')} \
 "
-

--- a/recipes-devtools/cargo/cargo-cross-canadian.inc
+++ b/recipes-devtools/cargo/cargo-cross-canadian.inc
@@ -9,7 +9,7 @@ require recipes-devtools/rust/rust-common.inc
 require cargo.inc
 
 CARGO = "${WORKDIR}/${CARGO_SNAPSHOT}/bin/cargo"
-BASEDEPENDS:remove = "cargo-native"
+BASEDEPENDS_remove = "cargo-native"
 
 export RUST_TARGET_PATH="${WORKDIR}/targets/"
 
@@ -37,7 +37,7 @@ python do_rust_gen_targets () {
     rust_gen_target(d, 'HOST', wd, "", "generic", d.getVar('HOST_ARCH'))
 }
 
-do_compile:prepend () {
+do_compile_prepend () {
 	PKG_CONFIG_PATH="${RECIPE_SYSROOT_NATIVE}/usr/lib/pkgconfig:${PKG_CONFIG_PATH}"
 }
 
@@ -70,5 +70,5 @@ do_install () {
 }
 
 PKG_SYS_BINDIR = "${SDKPATHNATIVE}/usr/bin"
-FILES:${PN} += "${base_prefix}/environment-setup.d ${PKG_SYS_BINDIR}"
+FILES_${PN} += "${base_prefix}/environment-setup.d ${PKG_SYS_BINDIR}"
 

--- a/recipes-devtools/cargo/cargo-cross-canadian_1.51.0.bb
+++ b/recipes-devtools/cargo/cargo-cross-canadian_1.51.0.bb
@@ -1,6 +1,6 @@
 require recipes-devtools/rust/rust-source-${PV}.inc
 require recipes-devtools/rust/rust-snapshot-${PV}.inc
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/cargo-${PV}:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/cargo-${PV}:"
 
 require cargo-cross-canadian.inc

--- a/recipes-devtools/cargo/cargo-cross-canadian_1.54.0.bb
+++ b/recipes-devtools/cargo/cargo-cross-canadian_1.54.0.bb
@@ -1,6 +1,6 @@
 require recipes-devtools/rust/rust-source-${PV}.inc
 require recipes-devtools/rust/rust-snapshot-${PV}.inc
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/cargo-${PV}:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/cargo-${PV}:"
 
 require cargo-cross-canadian.inc

--- a/recipes-devtools/cargo/cargo.inc
+++ b/recipes-devtools/cargo/cargo.inc
@@ -24,7 +24,7 @@ do_cargo_setup_snapshot () {
 addtask cargo_setup_snapshot after do_unpack before do_configure
 do_cargo_setup_snapshot[dirs] += "${WORKDIR}/${CARGO_SNAPSHOT}"
 
-do_compile:prepend () {
+do_compile_prepend () {
 	export RUSTC_BOOTSTRAP="1"
 }
 
@@ -46,5 +46,5 @@ BBCLASSEXTEND = "native nativesdk"
 
 # When building cargo-native we don't have cargo-native to use and depend on,
 # so we must use the locally set up snapshot to bootstrap the build.
-BASEDEPENDS:remove:class-native = "cargo-native"
-CARGO:class-native = "${WORKDIR}/${CARGO_SNAPSHOT}/bin/cargo"
+BASEDEPENDS_remove_class-native = "cargo-native"
+CARGO_class-native = "${WORKDIR}/${CARGO_SNAPSHOT}/bin/cargo"

--- a/recipes-devtools/rust/libstd-rs.inc
+++ b/recipes-devtools/rust/libstd-rs.inc
@@ -7,10 +7,10 @@ LIC_FILES_CHKSUM = "file://../../COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
 RUSTLIB_DEP = ""
 inherit cargo
 
-DEPENDS:append:libc-musl = " libunwind"
+DEPENDS_append_libc-musl = " libunwind"
 # rv32 does not have libunwind ported yet
-DEPENDS:remove:riscv32 = "libunwind"
-DEPENDS:remove:riscv64 = "libunwind"
+DEPENDS_remove_riscv32 = "libunwind"
+DEPENDS_remove_riscv64 = "libunwind"
 
 # Embed bitcode in order to allow compiling both with and without LTO
 RUSTFLAGS += "-Cembed-bitcode=yes"
@@ -23,7 +23,7 @@ CARGO_FEATURES ?= "panic-unwind backtrace"
 CARGO_BUILD_FLAGS += "--features '${CARGO_FEATURES}'"
 CARGO_VENDORING_DIRECTORY = "${RUSTSRC}/vendor"
 
-do_compile:prepend () {
+do_compile_prepend () {
     export CARGO_TARGET_DIR="${B}"
     # For Rust 1.13.0 and newer
     export RUSTC_BOOTSTRAP="1"

--- a/recipes-devtools/rust/rust-common.inc
+++ b/recipes-devtools/rust/rust-common.inc
@@ -287,7 +287,7 @@ TARGET_LLVM_FEATURES = "${@llvm_features(d)}"
 
 # class-native implies TARGET=HOST, and TUNE_FEATURES only describes the real
 # (original) target.
-TARGET_LLVM_FEATURES:class-native = "${@','.join(llvm_features_from_cc_arch(d))}"
+TARGET_LLVM_FEATURES_class-native = "${@','.join(llvm_features_from_cc_arch(d))}"
 
 def rust_gen_target(d, thing, wd, features, cpu, arch):
     import json

--- a/recipes-devtools/rust/rust-cross-canadian-common.inc
+++ b/recipes-devtools/rust/rust-cross-canadian-common.inc
@@ -39,13 +39,13 @@ export WRAPPER_TARGET_CCLD = "${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET
 export WRAPPER_TARGET_LDFLAGS = "${TARGET_LDFLAGS}"
 export WRAPPER_TARGET_AR = "${TARGET_PREFIX}ar"
 
-python do_configure:prepend() {
+python do_configure_prepend() {
     targets = [d.getVar("TARGET_SYS", True), "{}-unknown-linux-gnu".format(d.getVar("HOST_ARCH", True))]
     hosts = ["{}-unknown-linux-gnu".format(d.getVar("HOST_ARCH", True))]
 }
 
-INSANE_SKIP:${RUSTLIB_TARGET_PN} = "file-rdeps arch ldflags"
-SKIP_FILEDEPS:${RUSTLIB_TARGET_PN} = "1"
+INSANE_SKIP_${RUSTLIB_TARGET_PN} = "file-rdeps arch ldflags"
+SKIP_FILEDEPS_${RUSTLIB_TARGET_PN} = "1"
 
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"

--- a/recipes-devtools/rust/rust-cross-canadian.inc
+++ b/recipes-devtools/rust/rust-cross-canadian.inc
@@ -8,7 +8,7 @@ RUSTLIB_PKGS = "${RUSTLIB_SRC_PN} ${RUSTLIB_TARGET_PN} ${RUSTLIB_HOST_PN}"
 PN = "rust-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 
 PACKAGES = "${RUSTLIB_PKGS} ${PN}"
-RDEPENDS:${PN} += "${RUSTLIB_PKGS}"
+RDEPENDS_${PN} += "${RUSTLIB_PKGS}"
 
 # The default behaviour of x.py changed in 1.47+ so now we need to
 # explicitly ask for the stage 2 compiler to be assembled.
@@ -66,13 +66,13 @@ do_install () {
 PKG_SYS_LIBDIR = "${SDKPATHNATIVE}/usr/lib"
 PKG_SYS_BINDIR = "${SDKPATHNATIVE}/usr/bin"
 PKG_RUSTLIB_DIR = "${PKG_SYS_LIBDIR}/${TARGET_SYS}/rustlib"
-FILES:${PN} = "${PKG_SYS_LIBDIR}/*.so ${PKG_SYS_BINDIR} ${base_prefix}/environment-setup.d"
-FILES:${RUSTLIB_TARGET_PN} = "${PKG_RUSTLIB_DIR}/${TARGET_SYS} ${PKG_RUSTLIB_DIR}/${TARGET_SYS}.json"
-FILES:${RUSTLIB_HOST_PN} = "${PKG_RUSTLIB_DIR}/${BUILD_ARCH}-unknown-linux-gnu"
-FILES:${RUSTLIB_SRC_PN} = "${PKG_RUSTLIB_DIR}/src"
+FILES_${PN} = "${PKG_SYS_LIBDIR}/*.so ${PKG_SYS_BINDIR} ${base_prefix}/environment-setup.d"
+FILES_${RUSTLIB_TARGET_PN} = "${PKG_RUSTLIB_DIR}/${TARGET_SYS} ${PKG_RUSTLIB_DIR}/${TARGET_SYS}.json"
+FILES_${RUSTLIB_HOST_PN} = "${PKG_RUSTLIB_DIR}/${BUILD_ARCH}-unknown-linux-gnu"
+FILES_${RUSTLIB_SRC_PN} = "${PKG_RUSTLIB_DIR}/src"
 
-SUMMARY:${RUSTLIB_TARGET_PN} = "Rust cross canadian libaries for ${TARGET_SYS}"
-SUMMARY:${RUSTLIB_HOST_PN} = "Rust cross canadian libaries for ${HOST_SYS}"
-SUMMARY:${RUSTLIB_SRC_PN} = "Rust standard library sources for cross canadian toolchain"
-SUMMARY:${PN} = "Rust crost canadian compiler"
+SUMMARY_${RUSTLIB_TARGET_PN} = "Rust cross canadian libaries for ${TARGET_SYS}"
+SUMMARY_${RUSTLIB_HOST_PN} = "Rust cross canadian libaries for ${HOST_SYS}"
+SUMMARY_${RUSTLIB_SRC_PN} = "Rust standard library sources for cross canadian toolchain"
+SUMMARY_${PN} = "Rust crost canadian compiler"
 

--- a/recipes-devtools/rust/rust-cross-canadian_1.51.0.bb
+++ b/recipes-devtools/rust/rust-cross-canadian_1.51.0.bb
@@ -2,5 +2,4 @@ require rust-cross-canadian.inc
 require rust-source-${PV}.inc
 require rust-snapshot-${PV}.inc
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
-
+FILESEXTRAPATHS_prepend := "${THISDIR}/rust:"

--- a/recipes-devtools/rust/rust-cross-canadian_1.54.0.bb
+++ b/recipes-devtools/rust/rust-cross-canadian_1.54.0.bb
@@ -2,5 +2,4 @@ require rust-cross-canadian.inc
 require rust-source-${PV}.inc
 require rust-snapshot-${PV}.inc
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
-
+FILESEXTRAPATHS_prepend := "${THISDIR}/rust:"

--- a/recipes-devtools/rust/rust-cross.inc
+++ b/recipes-devtools/rust/rust-cross.inc
@@ -45,11 +45,11 @@ PN = "rust-cross-${TARGET_ARCH}"
 # FIXME: this should really be fixed in rust itself.
 # FIXME: using hard-coded relative paths is wrong, we should ask bitbake for
 #        the relative path between 2 of it's vars.
-HOST_POST_LINK_ARGS:append = " -Wl,-rpath=../../lib"
-BUILD_POST_LINK_ARGS:append = " -Wl,-rpath=../../lib"
+HOST_POST_LINK_ARGS_append = " -Wl,-rpath=../../lib"
+BUILD_POST_LINK_ARGS_append = " -Wl,-rpath=../../lib"
 
 # We need the same thing for the calls to the compiler when building the runtime crap
-TARGET_CC_ARCH:append = " --sysroot=${STAGING_DIR_TARGET}"
+TARGET_CC_ARCH_append = " --sysroot=${STAGING_DIR_TARGET}"
 
 do_rust_setup_snapshot () {
 }

--- a/recipes-devtools/rust/rust-llvm.inc
+++ b/recipes-devtools/rust/rust-llvm.inc
@@ -11,8 +11,8 @@ inherit cmake python3native
 
 DEPENDS += "ninja-native rust-llvm-native"
 
-ARM_INSTRUCTION_SET:armv5 = "arm"
-ARM_INSTRUCTION_SET:armv4t = "arm"
+ARM_INSTRUCTION_SET_armv5 = "arm"
+ARM_INSTRUCTION_SET_armv4t = "arm"
 
 LLVM_DIR = "llvm${LLVM_RELEASE}"
 
@@ -32,7 +32,7 @@ EXTRA_OECMAKE = " \
     -DLLVM_TARGET_ARCH=${TARGET_ARCH} \
     -DCMAKE_INSTALL_PREFIX:PATH=${libdir}/llvm-rust \
 "
-EXTRA_OECMAKE:append:class-target = "\
+EXTRA_OECMAKE_append_class-target = "\
     -DCMAKE_CROSSCOMPILING:BOOL=ON \
     -DLLVM_BUILD_TOOLS=OFF \
     -DLLVM_TABLEGEN=${STAGING_LIBDIR_NATIVE}/llvm-rust/bin/llvm-tblgen \
@@ -45,7 +45,7 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 
 export YOCTO_ALTERNATE_EXE_PATH = "${STAGING_LIBDIR}/llvm-rust/bin/llvm-config"
 
-do_install:append () {
+do_install_append () {
     # we don't need any of this stuff to build Rust
     rm -rf "${D}/usr/lib/cmake"
 }
@@ -53,11 +53,11 @@ do_install:append () {
 PACKAGES =+ "${PN}-bugpointpasses ${PN}-llvmhello ${PN}-liblto"
 
 # Add the extra locations to avoid the complaints about unpackaged files
-FILES:${PN}-bugpointpasses = "${libdir}/llvm-rust/lib/BugpointPasses.so"
-FILES:${PN}-llvmhello = "${libdir}/llvm-rust/lib/LLVMHello.so"
-FILES:${PN}-liblto = "${libdir}/llvm-rust/lib/libLTO.so.*"
-FILES:${PN}-staticdev =+ "${libdir}/llvm-rust/*/*.a"
-FILES:${PN} += "${libdir}/libLLVM*.so.* ${libdir}/llvm-rust/lib/*.so.* ${libdir}/llvm-rust/bin"
-FILES:${PN}-dev += "${datadir}/llvm ${libdir}/llvm-rust/lib/*.so ${libdir}/llvm-rust/include ${libdir}/llvm-rust/share ${libdir}/llvm-rust/lib/cmake"
+FILES_${PN}-bugpointpasses = "${libdir}/llvm-rust/lib/BugpointPasses.so"
+FILES_${PN}-llvmhello = "${libdir}/llvm-rust/lib/LLVMHello.so"
+FILES_${PN}-liblto = "${libdir}/llvm-rust/lib/libLTO.so.*"
+FILES_${PN}-staticdev =+ "${libdir}/llvm-rust/*/*.a"
+FILES_${PN} += "${libdir}/libLLVM*.so.* ${libdir}/llvm-rust/lib/*.so.* ${libdir}/llvm-rust/bin"
+FILES_${PN}-dev += "${datadir}/llvm ${libdir}/llvm-rust/lib/*.so ${libdir}/llvm-rust/include ${libdir}/llvm-rust/share ${libdir}/llvm-rust/lib/cmake"
 
 BBCLASSEXTEND = "native"

--- a/recipes-devtools/rust/rust-target.inc
+++ b/recipes-devtools/rust/rust-target.inc
@@ -3,8 +3,8 @@ require rust.inc
 DEPENDS += "rust-llvm (=${PV})"
 
 # Otherwise we'll depend on what we provide
-INHIBIT_DEFAULT_RUST_DEPS:class-native = "1"
+INHIBIT_DEFAULT_RUST_DEPS_class-native = "1"
 # We don't need to depend on gcc-native because yocto assumes it exists
-PROVIDES:class-native = "virtual/${TARGET_PREFIX}rust"
+PROVIDES_class-native = "virtual/${TARGET_PREFIX}rust"
 
 BBCLASSEXTEND = "native"

--- a/recipes-devtools/rust/rust-tools-cross-canadian.inc
+++ b/recipes-devtools/rust/rust-tools-cross-canadian.inc
@@ -7,7 +7,7 @@ RUST_TOOLS_PKGS = "${RUST_TOOLS_CLIPPY_PN} ${RUST_TOOLS_RUSTFMT_PN}"
 PN = "rust-tools-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 
 PACKAGES = "${RUST_TOOLS_CLIPPY_PN} ${RUST_TOOLS_RUSTFMT_PN} ${PN}"
-RDEPENDS:${PN} += "${RUST_TOOLS_PKGS}"
+RDEPENDS_${PN} += "${RUST_TOOLS_PKGS}"
 
 do_compile () {
     rust_runx build --stage 2 src/tools/clippy
@@ -26,13 +26,13 @@ do_install () {
     chown -R root.root ${D}
 }
 
-ALLOW_EMPTY:${PN} = "1"
+ALLOW_EMPTY_${PN} = "1"
 
 PKG_SYS_BINDIR = "${SDKPATHNATIVE}/usr/bin"
-FILES:${RUST_TOOLS_CLIPPY_PN} = "${PKG_SYS_BINDIR}/cargo-clippy ${PKG_SYS_BINDIR}/clippy-driver"
-FILES:${RUST_TOOLS_RUSTFMT_PN} = "${PKG_SYS_BINDIR}/rustfmt"
+FILES_${RUST_TOOLS_CLIPPY_PN} = "${PKG_SYS_BINDIR}/cargo-clippy ${PKG_SYS_BINDIR}/clippy-driver"
+FILES_${RUST_TOOLS_RUSTFMT_PN} = "${PKG_SYS_BINDIR}/rustfmt"
 
-SUMMARY:${PN} = "Rust helper tools"
-SUMMARY:${RUST_TOOLS_CLIPPY_PN} = "A collection of lints to catch common mistakes and improve your Rust code"
-SUMMARY:${RUST_TOOLS_RUSTFMT_PN} = "A tool for formatting Rust code according to style guidelines"
+SUMMARY_${PN} = "Rust helper tools"
+SUMMARY_${RUST_TOOLS_CLIPPY_PN} = "A collection of lints to catch common mistakes and improve your Rust code"
+SUMMARY_${RUST_TOOLS_RUSTFMT_PN} = "A tool for formatting Rust code according to style guidelines"
 

--- a/recipes-devtools/rust/rust-tools-cross-canadian_1.51.0.bb
+++ b/recipes-devtools/rust/rust-tools-cross-canadian_1.51.0.bb
@@ -2,5 +2,4 @@ require rust-tools-cross-canadian.inc
 require rust-source-${PV}.inc
 require rust-snapshot-${PV}.inc
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
-
+FILESEXTRAPATHS_prepend := "${THISDIR}/rust:"

--- a/recipes-devtools/rust/rust-tools-cross-canadian_1.54.0.bb
+++ b/recipes-devtools/rust/rust-tools-cross-canadian_1.54.0.bb
@@ -2,5 +2,4 @@ require rust-tools-cross-canadian.inc
 require rust-source-${PV}.inc
 require rust-snapshot-${PV}.inc
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/rust:"
-
+FILESEXTRAPATHS_prepend := "${THISDIR}/rust:"

--- a/recipes-devtools/rust/rust.inc
+++ b/recipes-devtools/rust/rust.inc
@@ -8,7 +8,7 @@ inherit rust
 inherit cargo_common
 
 DEPENDS += "file-native python3-native"
-DEPENDS:append:class-native = " rust-llvm-native"
+DEPENDS_append_class-native = " rust-llvm-native"
 
 S = "${RUSTSRC}"
 


### PR DESCRIPTION
This PR:

1. Rebases this repository on meta-rust/meta-rust revision 448047c7e4746eac8f0a96a2e3966b2219e2a4ca which updates Rust to 1.54.
2. Manually reverts some syntax changes to make the newer meta-rust codebase work with our older Bitbake version.

We should wait until the main repo is updated to 1.54 before merging this to keep the versions in sync.